### PR TITLE
Add PlayCanvas PHP prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Boat Shooting Prototype
+
+This repository contains a lightweight prototype for a browser-based shooting game built with [PlayCanvas](https://playcanvas.com/) and a PHP backend for score ranking.
+
+## Features
+
+- **Opening Movie** -> **Gameplay** -> **Ranking** -> **Ending Movie** -> **SNS Sharing**
+- Minimal PlayCanvas setup using the FPS Starter Kit (assets should be added to `public`)
+- Simple ranking API using PHP and MySQL for LAMP environments
+- Designed for mobile browsers
+
+## Setup
+
+1. Install Apache, PHP, and MySQL.
+2. Create a MySQL database and user:
+
+```sql
+CREATE DATABASE boatshooting;
+CREATE USER 'boatuser'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON boatshooting.* TO 'boatuser'@'localhost';
+```
+
+3. Create the `scores` table:
+
+```sql
+USE boatshooting;
+CREATE TABLE scores (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  score INT NOT NULL,
+  created_at DATETIME NOT NULL
+);
+```
+
+4. Place the contents of the `public` directory in your web server's document root.
+5. Update credentials in `server/config.php` if necessary.
+
+## Running
+
+Open `public/index.php` in your browser. The page displays an opening screen. Tapping **Start Game** launches the PlayCanvas app. After the game ends, the score can be submitted via the PHP endpoints. An ending screen provides options to restart and share the game on Twitter.
+
+## Notes
+
+- Actual PlayCanvas assets (FPS Starter Kit) should be imported into the project on [playcanvas.com](https://playcanvas.com/) and linked in `public/game.js`.
+- The included JavaScript and PHP are simplified for demonstration and do not represent a complete production-ready game.

--- a/public/game.js
+++ b/public/game.js
@@ -1,0 +1,55 @@
+// Basic structure for the PlayCanvas game
+var canvasContainer = document.getElementById('canvas-container');
+var opening = document.getElementById('opening');
+var ending = document.getElementById('ending');
+var startBtn = document.getElementById('startBtn');
+var shareBtn = document.getElementById('shareBtn');
+var restartBtn = document.getElementById('restartBtn');
+var app;
+
+function startGame() {
+    opening.style.display = 'none';
+    canvasContainer.style.display = 'block';
+
+    app = new pc.Application(canvasContainer, {
+        mouse: new pc.Mouse(canvasContainer),
+        touch: new pc.TouchDevice(canvasContainer)
+    });
+    app.start();
+
+    app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+    app.setCanvasResolution(pc.RESOLUTION_AUTO);
+    window.addEventListener('resize', function () {
+        app.resizeCanvas();
+    });
+
+    // Placeholder for loading FPS Starter Kit
+    // Here you would load PlayCanvas assets and scripts
+    // such as the FPS starter kit, scenes, and player controls.
+
+    // Example placeholder entity
+    var box = new pc.Entity('box');
+    box.addComponent('model', { type: 'box' });
+    app.root.addChild(box);
+    box.setLocalPosition(0, 0, 0);
+}
+
+function showEnding() {
+    canvasContainer.style.display = 'none';
+    ending.style.display = 'flex';
+}
+
+startBtn.addEventListener('click', startGame);
+restartBtn.addEventListener('click', function() {
+    ending.style.display = 'none';
+    startGame();
+});
+shareBtn.addEventListener('click', function() {
+    var text = encodeURIComponent('I just played Boat Shooting!');
+    var url = encodeURIComponent(window.location.href);
+    window.open('https://twitter.com/intent/tweet?text=' + text + '&url=' + url,
+        '_blank');
+});
+
+// This would be triggered when the game ends
+// showEnding();

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Boat Shooting Game</title>
+    <style>
+        body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+        #canvas-container { width: 100%; height: 100%; display: none; }
+        #opening { position: absolute; width: 100%; height: 100%; background: black; color: white; display: flex; justify-content: center; align-items: center; flex-direction: column; }
+        #ending { position: absolute; width: 100%; height: 100%; background: black; color: white; display: none; justify-content: center; align-items: center; flex-direction: column; }
+    </style>
+</head>
+<body>
+    <div id="opening">
+        <h1>Boat Shooting</h1>
+        <button id="startBtn">Start Game</button>
+    </div>
+    <div id="canvas-container"></div>
+    <div id="ending">
+        <h2>Game Over</h2>
+        <button id="shareBtn">Share on Twitter</button>
+        <button id="restartBtn">Restart</button>
+    </div>
+
+    <script src="https://code.playcanvas.com/playcanvas-stable.min.js"></script>
+    <script src="game.js"></script>
+</body>
+</html>

--- a/server/config.php
+++ b/server/config.php
@@ -1,0 +1,6 @@
+<?php
+// Database configuration
+define('DB_HOST', 'localhost');
+define('DB_NAME', 'boatshooting');
+define('DB_USER', 'boatuser');
+define('DB_PASS', 'password');

--- a/server/db.php
+++ b/server/db.php
@@ -1,0 +1,15 @@
+<?php
+require_once 'config.php';
+
+function getPDO() {
+    static $pdo;
+    if (!$pdo) {
+        $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+        $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    }
+    return $pdo;
+}

--- a/server/get_scores.php
+++ b/server/get_scores.php
@@ -1,0 +1,9 @@
+<?php
+require_once 'db.php';
+
+$pdo = getPDO();
+$stmt = $pdo->query('SELECT name, score FROM scores ORDER BY score DESC, id ASC LIMIT 10');
+$scores = $stmt->fetchAll();
+header('Content-Type: application/json');
+
+echo json_encode($scores);

--- a/server/submit_score.php
+++ b/server/submit_score.php
@@ -1,0 +1,15 @@
+<?php
+require_once 'db.php';
+
+$score = isset($_POST['score']) ? intval($_POST['score']) : 0;
+$name = isset($_POST['name']) ? trim($_POST['name']) : 'anonymous';
+
+if ($score > 0) {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('INSERT INTO scores (name, score, created_at) VALUES (?, ?, NOW())');
+    $stmt->execute([$name, $score]);
+    echo json_encode(['status' => 'ok']);
+} else {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'invalid score']);
+}


### PR DESCRIPTION
## Summary
- implement a lightweight PlayCanvas prototype with FPS starter placeholder
- add PHP ranking endpoints and database config
- create a simple HTML/JS frontend for the game flow
- document setup and running instructions

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cefd8bf388329ad74c5c20eeb2537