### PR TITLE
Add goal area and clear logic

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </div>
     <canvas id="canvas-container"></canvas>
     <div id="ending">
-        <h2>Game Over</h2>
+        <h2>Game Clear</h2>
         <button id="shareBtn">Share on Twitter</button>
         <button id="restartBtn">Restart</button>
     </div>


### PR DESCRIPTION
## Summary
- make new red goal area entity
- detect player position to trigger ending sequence
- feed goal area entity to PlayerControls
- display **Game Clear** instead of **Game Over**

## Testing
- `npm test` *(fails: Could not find package.json)*
- `php -l server/get_scores.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf818e00c8329b5cce118a45e2682