### PR TITLE
Fix pointer lock after game ends

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -104,6 +104,9 @@ function loadRanking() {
 }
 
 function showRanking(score) {
+    if (pc.Mouse.isPointerLocked()) {
+        app.mouse.disablePointerLock();
+    }
     canvasContainer.style.display = 'none';
     joystick.style.display = 'none';
     lookArea.style.display = 'none';
@@ -115,6 +118,9 @@ function showRanking(score) {
 }
 
 function showEnding() {
+    if (pc.Mouse.isPointerLocked()) {
+        app.mouse.disablePointerLock();
+    }
     ranking.style.display = 'none';
     ending.style.display = 'flex';
     if (endingVideo) {


### PR DESCRIPTION
## Summary
- exit pointer lock when showing ranking or ending screens

## Testing
- `php -l server/get_scores.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d231b36a483299266066bf55de926