### PR TITLE
Remove ranking and server code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+* Ranking functionality has been removed. Scores are stored only in the browser.
+* Do not add any server-side score submission or database access.
+* The ending screen displays the player's score and the share button tweets it.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,21 @@
 # Boat Shooting Prototype
 
-This repository contains a lightweight prototype for a browser-based shooting game built with [PlayCanvas](https://playcanvas.com/) and a PHP backend for score ranking.
+This repository contains a lightweight prototype for a browser-based shooting game built with [PlayCanvas](https://playcanvas.com/). It originally included a PHP backend for ranking, but scores are now kept only on the client.
 
 ## Features
 
-- **Opening Movie** -> **Gameplay** -> **Ranking** -> **Ending Movie** -> **SNS Sharing**
+- **Opening Movie** -> **Gameplay** -> **Ending Movie** -> **SNS Sharing**
 - Minimal PlayCanvas setup using the FPS Starter Kit (assets should be added to `public`)
-- Simple ranking API using PHP and MySQL for LAMP environments
 - Designed for mobile browsers with on-screen joystick and touch look controls
 
 ## Setup
 
-1. Install Apache, PHP, and MySQL.
-2. Create a MySQL database and user:
-
-```sql
-CREATE DATABASE boatshooting;
-CREATE USER 'boatuser'@'localhost' IDENTIFIED BY 'password';
-GRANT ALL PRIVILEGES ON boatshooting.* TO 'boatuser'@'localhost';
-```
-
-3. Create the `scores` table:
-
-```sql
-USE boatshooting;
-CREATE TABLE scores (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
-  score INT NOT NULL,
-  created_at DATETIME NOT NULL
-);
-```
-
-4. Place the contents of the `public` directory in your web server's document root.
-   To try the full ranking flow locally you need a PHP server. A simple option is
-   to run `php -S localhost:8000` from the repository root and access
-   `http://localhost:8000/public/`. Running `python -m http.server` only serves
-   static files and will not execute the PHP scripts used for score submission.
-5. Update credentials in `server/config.php` if necessary.
+1. Place the contents of the `public` directory in your web server's document root.
+   Because scores are stored only in the browser, no PHP or database setup is required.
 
 ## Running
 
-Open `public/index.html` in your browser. The page displays an opening screen. Tapping **Start Game** launches the PlayCanvas app. After the game ends, scores are exchanged with the PHP backend via AJAX, and a ranking list is displayed. The ending screen provides options to restart and share the game on Twitter. On touch devices, a joystick is shown for movement and dragging the right side rotates the camera. A quick tap on the right fires a shot.
+Open `public/index.html` in your browser. The page displays an opening screen. Tapping **Start Game** launches the PlayCanvas app. After the game ends, a score is shown on the ending screen and can be shared on Twitter. On touch devices, a joystick is shown for movement and dragging the right side rotates the camera. A quick tap on the right fires a shot.
 
 ## Notes
 

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
         #canvas-container { width: 100%; height: 100%; display: none; }
         #opening { position: absolute; width: 100%; height: 100%; background: black; color: white; display: flex; justify-content: center; align-items: center; flex-direction: column; }
         #ending { position: absolute; width: 100%; height: 100%; background: black; color: white; display: none; justify-content: center; align-items: center; flex-direction: column; }
-        #ranking { position: absolute; width: 100%; height: 100%; background: rgba(0,0,0,0.8); color: white; display: none; justify-content: center; align-items: center; flex-direction: column; }
         #joystick, #lookArea { position: absolute; display: none; touch-action: none; }
         #joystick { bottom: 20px; left: 20px; width: 120px; height: 120px; border-radius: 60px; background: rgba(255,255,255,0.2); }
         #stick { position: absolute; width: 60px; height: 60px; top: 30px; left: 30px; border-radius: 30px; background: rgba(255,255,255,0.5); }
@@ -26,19 +25,10 @@
     <div id="lookArea"></div>
     <div id="ending">
         <h2>Game Clear</h2>
+        <div id="finalScore"></div>
         <video id="endingVideo" src="ending.mp4" style="display:none" width="320" height="240"></video>
         <button id="shareBtn">Share on Twitter</button>
         <button id="restartBtn">Restart</button>
-    </div>
-    <div id="ranking">
-        <h2>Ranking</h2>
-        <ol id="scoreList"></ol>
-        <form id="scoreForm">
-            <input type="text" id="playerName" placeholder="Name" required>
-            <input type="hidden" id="playerScore">
-            <button type="submit">Submit Score</button>
-        </form>
-        <button id="closeRanking">Close</button>
     </div>
 
     <script src="https://code.playcanvas.com/playcanvas-stable.min.js"></script>


### PR DESCRIPTION
## Summary
- update guidelines in `AGENTS.md`
- remove ranking elements from the HTML and JS
- display the calculated score on the ending screen
- update the share tweet message with the score
- document new workflow without server in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d2f658f1483299b915da38cb43ad9